### PR TITLE
:recycle: Update starter to current best practices

### DIFF
--- a/include/resource_list.hpp
+++ b/include/resource_list.hpp
@@ -23,10 +23,25 @@
 
 struct resource_list
 {
-  hal::callback<void()> reset;
+  /// Initialized 1st
+  hal::callback<void()> reset = +[] {
+    while (true) {
+      continue;
+    }
+  };
+  // Both status_led and clock are required in order to generate the terminate
+  // blink pattern.
   std::optional<hal::output_pin*> status_led;
-  std::optional<hal::serial*> console;
   std::optional<hal::steady_clock*> clock;
+  // Initialize 3rd to support logging error messages
+  std::optional<hal::serial*> console;
 };
 
-resource_list initialize_platform();
+/**
+ * @brief Initializes the target platform and the resource list
+ *
+ * @param p_list - the list of resources to initialize for the application to
+ * run properly. The initialize platform library should initialize each resource
+ * in the resoure list.
+ */
+void initialize_platform(resource_list& p_list);

--- a/platforms/lpc4074.cpp
+++ b/platforms/lpc4074.cpp
@@ -16,4 +16,5 @@
 // file is minimally this, then this shouldn't be an issue. This becomes a
 // problem if such a scheme is abused. So only do this for identical platform
 // implementations.
+
 #include "lpc4078.cpp"  // NOLINT(bugprone-suspicious-include)

--- a/platforms/micromod.cpp
+++ b/platforms/micromod.cpp
@@ -16,16 +16,14 @@
 
 #include <resource_list.hpp>
 
-resource_list initialize_platform()
+void initialize_platform(resource_list& p_list)
 {
   using namespace hal::literals;
+  p_list.reset = +[]() { hal::micromod::v1::reset(); },
 
   hal::micromod::v1::initialize_platform();
 
-  return {
-    .reset = +[]() { hal::micromod::v1::reset(); },
-    .status_led = &hal::micromod::v1::led(),
-    .console = &hal::micromod::v1::console(hal::buffer<128>),
-    .clock = &hal::micromod::v1::uptime_clock(),
-  };
+  p_list.status_led = &hal::micromod::v1::led();
+  p_list.clock = &hal::micromod::v1::uptime_clock();
+  p_list.console = &hal::micromod::v1::console(hal::buffer<128>);
 }

--- a/platforms/stm32f103c8.cpp
+++ b/platforms/stm32f103c8.cpp
@@ -21,28 +21,25 @@
 
 #include <resource_list.hpp>
 
-resource_list initialize_platform()
+void initialize_platform(resource_list& p_list)
 {
   using namespace hal::literals;
 
+  p_list.reset = +[]() { hal::cortex_m::reset(); };
   // Set the MCU to the maximum clock speed
   hal::stm32f1::maximum_speed_using_internal_oscillator();
 
   static hal::cortex_m::dwt_counter counter(
     hal::stm32f1::frequency(hal::stm32f1::peripheral::cpu));
+  p_list.clock = &counter;
+
+  static hal::stm32f1::output_pin led('C', 13);
+  p_list.status_led = &led;
 
   static hal::stm32f1::uart uart1(hal::port<1>,
                                   hal::buffer<128>,
                                   hal::serial::settings{
                                     .baud_rate = 115200,
                                   });
-
-  static hal::stm32f1::output_pin led('C', 13);
-
-  return {
-    .reset = +[]() { hal::cortex_m::reset(); },
-    .status_led = &led,
-    .console = &uart1,
-    .clock = &counter,
-  };
+  p_list.console = &uart1;
 }


### PR DESCRIPTION
Rather than returning a whole resource list, pass by reference and update each field individually. This allows each driver to be initialized and set in the list, allowing a status indicator or log information over serial.